### PR TITLE
Release 1.0.11

### DIFF
--- a/build/RNIdnow.m
+++ b/build/RNIdnow.m
@@ -57,7 +57,8 @@
 	// this was breaking so I commented it
 	// self.settings.ignoreCompanyID = options[@"ignoreCompanyID"];
 	self.settings.forceModalPresentation = options[@"forceModalPresentation"];
-	self.settings.enableWaitingScreenCustomised = options[@"enableWaitingScreenCustomised"];
+	// this was breaking so I commented it
+	// self.settings.enableWaitingScreenCustomised = options[@"enableWaitingScreenCustomised"];
 	self.settings.userInterfaceLanguage = options[@"userInterfaceLanguage"];
 	// this was breaking so I commented it
 	// self.settings.showIdentTokenOnCheckScreen = options[@"showIdentTokenOnCheckScreen"];

--- a/build/withIDnow.js
+++ b/build/withIDnow.js
@@ -21,7 +21,7 @@ const withPodfileUpdate = (config) => {
                     'enable_user_defined_build_types!',
                 ]);
                 podfile = addLines(podfile, 'config = use_native_modules!', 1, [
-                    "  pod 'IDnowSDK', '5.1.6', :build_type => :static_framework",
+                    "  pod 'IDnowSDK', '5.1.9', :build_type => :static_framework",
                     "  pod 'AFNetworking', '4.0.1', :modular_headers => true",
                     "  pod 'FLAnimatedImage', '1.0.16', :modular_headers => true",
                     "  pod 'libPhoneNumber-iOS', '0.9.15', :modular_headers => true",
@@ -272,4 +272,4 @@ const withIDnow = (expoConfig) => {
     expoConfig = withXCodeProjectUpdate(expoConfig);
     return expoConfig;
 };
-exports.default = (0, config_plugins_1.createRunOncePlugin)(withIDnow, 'IDNowSDK', '1.0.10');
+exports.default = (0, config_plugins_1.createRunOncePlugin)(withIDnow, 'IDNowSDK', '1.0.11');

--- a/build/withIDnow.js
+++ b/build/withIDnow.js
@@ -21,7 +21,7 @@ const withPodfileUpdate = (config) => {
                     'enable_user_defined_build_types!',
                 ]);
                 podfile = addLines(podfile, 'config = use_native_modules!', 1, [
-                    "  pod 'IDnowSDK', '5.1.9', :build_type => :static_framework",
+                    "  pod 'IDnowSDK', '5.1.6', :build_type => :static_framework",
                     "  pod 'AFNetworking', '4.0.1', :modular_headers => true",
                     "  pod 'FLAnimatedImage', '1.0.16', :modular_headers => true",
                     "  pod 'libPhoneNumber-iOS', '0.9.15', :modular_headers => true",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@heyfina/config-plugin-react-native-idnow",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Config plugin to auto configure react-native-idnow",
   "main": "build/withIDnow.js",
   "types": "build/withIDnow.d.ts",
@@ -27,8 +27,8 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "@expo/config-plugins": "^4.0.15",
-    "@expo/config-types": "^43.0.1"
+    "@expo/config-plugins": "4.1.1",
+    "@expo/config-types": "44.0.0"
   },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"

--- a/src/RNIdnow.m
+++ b/src/RNIdnow.m
@@ -57,7 +57,8 @@
 	// this was breaking so I commented it
 	// self.settings.ignoreCompanyID = options[@"ignoreCompanyID"];
 	self.settings.forceModalPresentation = options[@"forceModalPresentation"];
-	self.settings.enableWaitingScreenCustomised = options[@"enableWaitingScreenCustomised"];
+	// this was breaking so I commented it
+	// self.settings.enableWaitingScreenCustomised = options[@"enableWaitingScreenCustomised"];
 	self.settings.userInterfaceLanguage = options[@"userInterfaceLanguage"];
 	// this was breaking so I commented it
 	// self.settings.showIdentTokenOnCheckScreen = options[@"showIdentTokenOnCheckScreen"];

--- a/src/withIDnow.ts
+++ b/src/withIDnow.ts
@@ -38,7 +38,7 @@ const withPodfileUpdate = (config: ExpoConfig) => {
           'enable_user_defined_build_types!',
         ]);
         podfile = addLines(podfile, 'config = use_native_modules!', 1, [
-          "  pod 'IDnowSDK', '5.1.9', :build_type => :static_framework",
+          "  pod 'IDnowSDK', '5.1.6', :build_type => :static_framework",
           "  pod 'AFNetworking', '4.0.1', :modular_headers => true",
           "  pod 'FLAnimatedImage', '1.0.16', :modular_headers => true",
           "  pod 'libPhoneNumber-iOS', '0.9.15', :modular_headers => true",

--- a/src/withIDnow.ts
+++ b/src/withIDnow.ts
@@ -38,7 +38,7 @@ const withPodfileUpdate = (config: ExpoConfig) => {
           'enable_user_defined_build_types!',
         ]);
         podfile = addLines(podfile, 'config = use_native_modules!', 1, [
-          "  pod 'IDnowSDK', '5.1.6', :build_type => :static_framework",
+          "  pod 'IDnowSDK', '5.1.9', :build_type => :static_framework",
           "  pod 'AFNetworking', '4.0.1', :modular_headers => true",
           "  pod 'FLAnimatedImage', '1.0.16', :modular_headers => true",
           "  pod 'libPhoneNumber-iOS', '0.9.15', :modular_headers => true",
@@ -376,4 +376,4 @@ const withIDnow: ConfigPlugin = (expoConfig: ExpoConfig) => {
   return expoConfig;
 };
 
-export default createRunOncePlugin(withIDnow, 'IDNowSDK', '1.0.10');
+export default createRunOncePlugin(withIDnow, 'IDNowSDK', '1.0.11');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1204,7 +1204,7 @@
     xcode "^3.0.1"
     xml2js "^0.4.23"
 
-"@expo/config-plugins@4.0.15", "@expo/config-plugins@^4.0.15":
+"@expo/config-plugins@4.0.15":
   version "4.0.15"
   resolved "https://registry.yarnpkg.com/@expo/config-plugins/-/config-plugins-4.0.15.tgz#cc170a0cf890973b6491cf357540e9955296019c"
   integrity sha512-QqxVEt2bFu3ZuI1soULRJv7i0Zrg/FMZ0IxNV7Y3AjH7fhtUJH3pPo9f6MURvqNr+PLxhBlkofkWfunrVejSkw==
@@ -1225,6 +1225,32 @@
     slash "^3.0.0"
     xcode "^3.0.1"
     xml2js "0.4.23"
+
+"@expo/config-plugins@4.1.1":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@expo/config-plugins/-/config-plugins-4.1.1.tgz#ffb20b3d2be4e2509e8bf846721641dc072718c7"
+  integrity sha512-lo3tVxRhwM9jfxPHJcURsH5WvU26kX12h5EB3C7kjVhgdQPLkvT8Jk8Cx0KSL8MXKcry2xQvZ2uuwWLkMeplJw==
+  dependencies:
+    "@expo/config-types" "^44.0.0"
+    "@expo/json-file" "8.2.35"
+    "@expo/plist" "0.0.18"
+    "@expo/sdk-runtime-versions" "^1.0.0"
+    "@react-native/normalize-color" "^2.0.0"
+    chalk "^4.1.2"
+    debug "^4.3.1"
+    find-up "~5.0.0"
+    getenv "^1.0.0"
+    glob "7.1.6"
+    resolve-from "^5.0.0"
+    semver "^7.3.5"
+    slash "^3.0.0"
+    xcode "^3.0.1"
+    xml2js "0.4.23"
+
+"@expo/config-types@44.0.0", "@expo/config-types@^44.0.0":
+  version "44.0.0"
+  resolved "https://registry.yarnpkg.com/@expo/config-types/-/config-types-44.0.0.tgz#d3480fe2c99f9e895dae4ebba58b74ed72d03e26"
+  integrity sha512-d+gpdKOAhqaD5RmcMzGgKzNtvE1w+GCqpFQNSXLliYlXjj+Tv0eL8EPeAdPtvke0vowpPFwd5McXLA90dgY6Jg==
 
 "@expo/config-types@^40.0.0-beta.2":
   version "40.0.0-beta.2"
@@ -1323,6 +1349,15 @@
     json5 "^1.0.1"
     write-file-atomic "^2.3.0"
 
+"@expo/json-file@8.2.35":
+  version "8.2.35"
+  resolved "https://registry.yarnpkg.com/@expo/json-file/-/json-file-8.2.35.tgz#d0f0c74cdde2ae26686708912cf23ff81a8d67ac"
+  integrity sha512-cQFLGSNRRFbN9EIhVDpMCYuzXbrHUOmKEqitBR+nrU6surjKGsOsN9Ubyn/L/LAGlFvT293E4XY5zsOtJyiPZQ==
+  dependencies:
+    "@babel/code-frame" "~7.10.4"
+    json5 "^1.0.1"
+    write-file-atomic "^2.3.0"
+
 "@expo/npm-proofread@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@expo/npm-proofread/-/npm-proofread-1.0.1.tgz#8450f71cea47dd9864d61a1a105931dc7ea2209a"
@@ -1343,6 +1378,15 @@
   version "0.0.16"
   resolved "https://registry.yarnpkg.com/@expo/plist/-/plist-0.0.16.tgz#c7d294a774196cfa1d8caf89a75ba923f5d1d53c"
   integrity sha512-yQMt2CTm2VNLiHv2/EqHYrHvfflI2mFJd+DZIQQy569hvpZle0CxMPGH1p2KatbrO8htxJNvwrlR/4TIwhQJ5w==
+  dependencies:
+    "@xmldom/xmldom" "~0.7.0"
+    base64-js "^1.2.3"
+    xmlbuilder "^14.0.0"
+
+"@expo/plist@0.0.18":
+  version "0.0.18"
+  resolved "https://registry.yarnpkg.com/@expo/plist/-/plist-0.0.18.tgz#9abcde78df703a88f6d9fa1a557ee2f045d178b0"
+  integrity sha512-+48gRqUiz65R21CZ/IXa7RNBXgAI/uPSdvJqoN9x1hfL44DNbUoWHgHiEXTx7XelcATpDwNTz6sHLfy0iNqf+w==
   dependencies:
     "@xmldom/xmldom" "~0.7.0"
     base64-js "^1.2.3"


### PR DESCRIPTION
- disable `enableWaitingScreenCustomised` flag (broke builds)

Bumb version of packages:
- `"@expo/config-plugins"`: `"4.1.1"`
- `"@expo/config-types"`: `"44.0.0"`